### PR TITLE
Fix pr id check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anilanar/moxci",
-  "version": "0.0.3-rc.1",
+  "version": "0.0.3-rc.2",
   "description": "tool to notify circleci build artifacts as a github commit status.",
   "homepage": "https://github.com/anilanar/moxci#readme",
   "repository": "https://github.com/anilanar/moxci.git",
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepublish": "yarn && yarn build",
+    "prepublishOnly": "yarn && yarn build",
     "test": "node src/index.test.ts",
     "type-check": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anilanar/moxci",
-  "version": "0.0.2",
+  "version": "0.0.3-rc.1",
   "description": "tool to notify circleci build artifacts as a github commit status.",
   "homepage": "https://github.com/anilanar/moxci#readme",
   "repository": "https://github.com/anilanar/moxci.git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "publish": "yarn && yarn build",
+    "prepublish": "yarn && yarn build",
     "test": "node src/index.test.ts",
     "type-check": "tsc --noEmit"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,11 @@ type Options = {
 
 export const moxci = async (targetPath: string, options: Options) => {
   const {
-    CIRCLE_PULL_REQUEST,
     CIRCLE_BUILD_NUM,
     GITHUB_TOKEN,
     CIRCLE_TOKEN,
     CIRCLE_PROJECT_USERNAME,
     CIRCLE_PROJECT_REPONAME,
-    SLACK_WEBHOOK,
     CIRCLE_SHA1
   } = process.env;
 
@@ -26,11 +24,6 @@ export const moxci = async (targetPath: string, options: Options) => {
 
   if (!CIRCLE_PROJECT_REPONAME) {
     console.error("Cannot find project reponame");
-    return;
-  }
-
-  if (!CIRCLE_PULL_REQUEST) {
-    console.error("Cannot find pull request ID");
     return;
   }
 
@@ -54,11 +47,6 @@ export const moxci = async (targetPath: string, options: Options) => {
 
   // Github
   if (GITHUB_TOKEN) {
-    const pullRequestId = Number(CIRCLE_PULL_REQUEST.split("/").pop());
-    if (!pullRequestId) {
-      console.error("Invalid Pull Request Id");
-      return;
-    }
     notifyGithubPr({
       owner: CIRCLE_PROJECT_USERNAME,
       repo: CIRCLE_PROJECT_REPONAME,


### PR DESCRIPTION
Removed existence check for pull request ids. Github Status API works for commits, not for PRs so PR ids are irrelevant.